### PR TITLE
Fixed #59 Add check if ghost and pacman are in the same x and y map coordinates

### DIFF
--- a/ghost.js
+++ b/ghost.js
@@ -95,8 +95,8 @@ class Ghost {
         }
 
     }
-
-    checkGhostCollission() {
+    
+    checkGhostCollision() {
 
     }
 

--- a/pacman.js
+++ b/pacman.js
@@ -94,8 +94,14 @@ class Pacman {
 
     }
 
-    checkGhostCollission() {
-
+    checkGhostCollision() {
+        for(let i = 0; i < ghosts.length; i++) {
+            let ghost = ghosts[i];
+            if(ghost.getMapX() == this.getMapX() && ghost.getMapY() == this.getMapY()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     changeDirectionIfPossible() {


### PR DESCRIPTION
Hasn't been called yet but will call when pacman/ghost are moving to return true if they are which will prompt another function based on the state of the pacman and game or false - which will continue the game as if nothing happened